### PR TITLE
Removed debug. Output streams again

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -43,8 +43,6 @@ if (!phantom) {
   console.log('Open a browser and navigate to "http://localhost:' + port + '"');
 } else {
   var proc = runbrowser.runPhantom('http://localhost:' + port + '/');
-  if (debug) {
-    proc.stdout.pipe(process.stdout);
-    proc.stderr.pipe(process.stderr);
-  }
+  proc.stdout.pipe(process.stdout);
+  proc.stderr.pipe(process.stderr);
 }

--- a/index.js
+++ b/index.js
@@ -87,9 +87,6 @@ function createHandler(filename, reports, phantom) {
     if ('/results' === req.url && req.method === 'POST') {
       return req.pipe(JSONStream.parse('*')).once('data', function (results) {
 
-        // print TAP results
-        console.log(results.consoleLog);
-
         if (results.coverage) {
           var collector = new istanbul.Collector();
           var reporter = new istanbul.Reporter();


### PR DESCRIPTION
The code coverage feature with istanbul resulted in behavior where phantomjs output was no longer streamed to stdout. This makes it hard to know when your long-running tests hang. This PR removes the debug option as an option and makes it a feature. It removes the printing of console.log from index.js when results are posted.