### PR TITLE
coverage from once() -> on()

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function createHandler(filename, reports, phantom) {
       });
     }
     if ('/results' === req.url && req.method === 'POST') {
-      return req.pipe(JSONStream.parse('*')).once('data', function (results) {
+      return req.pipe(JSONStream.parse('*')).on('data', function (results) {
 
         // print TAP results
         console.log(results.consoleLog);


### PR DESCRIPTION
This sets the reporting of coverage from once() to on() so you get results reported for multiple browsers when in non-phantom mode. 

In the future, it would be interesting to find a way to take coverage results from multiple browsers and munge them together into only one report (as opposed to overwriting previous reports when results from a new browser are received)