### PR TITLE
Fix exit code on --phantom mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function createHandler(filename, reports, phantom) {
           res.statusCode === 200;
           res.end('OK');
           var passed = results.tap.fail.length === 0;
-          if (phantom) process.exit(res.passed ? 0 : 1);
+          if (phantom) process.exit(passed ? 0 : 1);
         }
       })
     }


### PR DESCRIPTION
Currently run-browser always exits with code `1` on `—phantom` mode. `res.passed` always becomes `undefined`.

Probably `passed` was taken for `res.passed`.