### PR TITLE
Add babelify to support es6 features.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,6 +17,7 @@ var phantom = args.b || args.phantom || args.phantomjs;
 var report = args.p || args.report || args.istanbul;
 var debug = args.d || args.debug;
 var timeout = args.t || args.timeout || Infinity;
+var babelify = args.e || args.babelify || false;
 
 if (help) {
   var helpText = [
@@ -25,6 +26,7 @@ if (help) {
     '  run-browser <file> <options>',
     '',
     'Options:',
+    '  -e --babelify      Use babelify transformer for es6 harmony support',
     '  -p --port <number> The port number to run the server on (default: 3000)',
     '  -b --phantom       Use the phantom headless browser to run tests and then exit with the correct status code (if tests output TAP)',
     '  -r --report        Generate coverage Istanbul report. Repeat for each type of coverage report desired. (default: text only)',
@@ -38,7 +40,7 @@ if (help) {
   process.exit(process.argv.length === 3 ? 0 : 1);
 }
 
-var server = runbrowser(filename, report, phantom);
+var server = runbrowser(filename, report, phantom, babelify);
 server.listen(port);
 
 if (!phantom) {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "bin": "./bin/cli.js",
   "keywords": [],
   "dependencies": {
+    "babelify": "^6.0.0",
     "browserify": "^3.28.0",
     "browserify-istanbul": "^0.1.2",
     "function-bind": "^1.0.2",


### PR DESCRIPTION
Looks like phantomJS 2.0 is not ready to be picked up by Medium/phantomjs yet, and also it uses a webkit forked several months old so people can't use the latest es6 features already supported by Chrome / Firefox.

Add babelify transformer to support es6 features in headless testings.