### PR TITLE
handles() returns true for /results url

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,5 +113,7 @@ function createHandler(filename, reports, phantom) {
 }
 
 function handles(req) {
-  return req.url === '/' || req.url === '/tests-bundle.js';
+  return (req.url === '/' && req.method === 'GET') ||
+    (req.url === '/tests-bundle.js' && req.method === 'GET') ||
+    ('/results' === req.url && req.method === 'POST');
 }


### PR DESCRIPTION
Handles returns true for results. This is necessary for custom servers.

Please version bump to 2.0.3 once this is accepted.

@Raynos 
