### PR TITLE
Add minimatch ignore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The simplest way to run testling type tests in the browser
       -b --phantom       Use the phantom headless browser to run tests and then exit with the correct status code (if tests output TAP)
       -r --report        Generate coverage Istanbul report. Repeat for each type of coverage report desired. (default: text only)
       -t --timeout       Global timeout in milliseconds for tests to finish. (default: Infinity)
+      -i --ignore        Ignore file patterns when instrumenting code. (Use https://www.npmjs.com/package/minimatch patterns)
 
     Example:
       run-browser test-file.js --port 3030 --report text --report html --report=cobertura

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -15,6 +15,7 @@ var port = Number(args.p || args.port) || 3000;
 var help = args.help || args.h || args._.length === 0;
 var phantom = args.b || args.phantom || args.phantomjs;
 var report = args.p || args.report || args.istanbul;
+var ignore = args.i || args.ignore;
 var debug = args.d || args.debug;
 var timeout = args.t || args.timeout || Infinity;
 
@@ -29,6 +30,7 @@ if (help) {
     '  -b --phantom       Use the phantom headless browser to run tests and then exit with the correct status code (if tests output TAP)',
     '  -r --report        Generate coverage Istanbul report. Repeat for each type of coverage report desired. (default: text only)',
     '  -t --timeout       Global timeout in milliseconds for tests to finish. (default: Infinity)',
+    '  -i --ignore        Ignore file patterns when instrumenting code. (Use https://www.npmjs.com/package/minimatch patterns)',
     '',
     'Example:',
     '  run-browser test-file.js --port 3030 --report text --report html --report=cobertura',
@@ -38,7 +40,13 @@ if (help) {
   process.exit(process.argv.length === 3 ? 0 : 1);
 }
 
-var server = runbrowser(filename, report, phantom);
+var options = {
+  reports: report,
+  phantom: phantom,
+  ignore: ignore
+};
+
+var server = runbrowser(filename, options);
 server.listen(port);
 
 if (!phantom) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "process": "^0.9.0",
     "tap-finished": "0.0.1",
     "through2-spy": "^1.2.0",
-    "xhr": "^1.17.0"
+    "xhr": "^1.17.0",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "linify": "^1.0.1"


### PR DESCRIPTION
So with browserify, there really isn't a way to have the `b.transform()` run after the package.json specified transforms. This leads to situations where projects that use transforms like `jadeify` can't use the coverage option with istanbul because istanbul attempts to instrument a file it can't parse. 

This pull request allows you to add ignore minimatch patterns to browserify-istanbul so it doesn't attempt to instrument files it can't parse.

e.g. 

```
run-browser --phantom --report text --report html --ignore '**/*.jade'
```

FWIW, this breaks the current interface by moving multiple arguments to an `options` object. Suggest publishing as a new major version, 3.0.0.

@Raynos @ForbesLindesay 
