### PR TITLE
Add server mocking capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The simplest way to run testling type tests in the browser
       -b --phantom       Use the phantom headless browser to run tests and then exit with the correct status code (if tests output TAP)
       -r --report        Generate coverage Istanbul report. Repeat for each type of coverage report desired. (default: text only)
       -t --timeout       Global timeout in milliseconds for tests to finish. (default: Infinity)
+      -m --mock          Include given JS file and use for handling requests to /mock*
+
 
     Example:
       run-browser test-file.js --port 3030 --report text --report html --report=cobertura
@@ -50,6 +52,19 @@ server.listen(3000);
 ```
 
 For advanced phantomjs usage, just read the source in `./bin/cli.js`
+
+## Mock server
+
+If you pass `-m localfile.js` argument, the file is expected to export a function for handling requests to `/mock*`
+
+```js
+module.exports = function (req, res) {
+    if (req.url === '/mock/no-content') {
+        res.statusCode = 204
+        res.end('')
+    }
+}
+```
 
 ## License
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,6 +17,7 @@ var phantom = args.b || args.phantom || args.phantomjs;
 var report = args.p || args.report || args.istanbul;
 var debug = args.d || args.debug;
 var timeout = args.t || args.timeout || Infinity;
+var mockserver = args.m || args.mock;
 
 if (help) {
   var helpText = [
@@ -29,6 +30,7 @@ if (help) {
     '  -b --phantom       Use the phantom headless browser to run tests and then exit with the correct status code (if tests output TAP)',
     '  -r --report        Generate coverage Istanbul report. Repeat for each type of coverage report desired. (default: text only)',
     '  -t --timeout       Global timeout in milliseconds for tests to finish. (default: Infinity)',
+    '  -m --mock          Include given JS file and use for handling requests to /mock*',
     '',
     'Example:',
     '  run-browser test-file.js --port 3030 --report text --report html --report=cobertura',
@@ -38,7 +40,7 @@ if (help) {
   process.exit(process.argv.length === 3 ? 0 : 1);
 }
 
-var server = runbrowser(filename, report, phantom);
+var server = runbrowser(filename, report, phantom, mockserver);
 server.listen(port);
 
 if (!phantom) {


### PR DESCRIPTION
I wanted to add that for a long while, but only got down to it after I saw https://github.com/Raynos/xhr/pull/112

This is adding a `-m` option for including a bit of code, that would handle all requests starting with `/mock` on the server that `run-browser` is setting up for testing.

Please note that running a server on a different port in parallel has two issues:
1. it's cross-domain for the running JS tests
2. it's hard to incorporate it into a pipe `run-browser | tap-something` 
